### PR TITLE
CI: Fix file structure deployment issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,10 +130,40 @@ jobs:
         username: ${{ secrets.SERVER_USER }}
         key: ${{ secrets.SERVER_SSH_KEY }}
         port: ${{ secrets.SERVER_PORT || 22 }}
-        source: "composeApp/build/dist/wasmJs/productionExecutable/**"
+        source: "composeApp/build/dist/wasmJs/productionExecutable/*"
         target: "/var/www/drivebit-clients"
         strip_components: 0
         overwrite: true
+
+    - name: Fix file structure (move files to correct location)
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.SERVER_HOST }}
+        username: ${{ secrets.SERVER_USER }}
+        key: ${{ secrets.SERVER_SSH_KEY }}
+        port: ${{ secrets.SERVER_PORT || 22 }}
+        script: |
+          set -e
+          echo "🔧 Fixing file structure..."
+          if [ "$EUID" -ne 0 ]; then SUDO_CMD="sudo"; else SUDO_CMD=""; fi
+          
+          # Move files from nested structure to root if needed
+          if [ -d "/var/www/drivebit-clients/composeApp/build/dist/wasmJs/productionExecutable" ]; then
+            echo "📁 Moving files from nested structure..."
+            $SUDO_CMD mv /var/www/drivebit-clients/composeApp/build/dist/wasmJs/productionExecutable/* /var/www/drivebit-clients/
+            $SUDO_CMD rm -rf /var/www/drivebit-clients/composeApp
+            echo "✅ Files moved to correct location"
+          else
+            echo "ℹ️  Files already in correct location"
+          fi
+          
+          # Verify index.html exists
+          if [ -f "/var/www/drivebit-clients/index.html" ]; then
+            echo "✅ index.html found in correct location"
+          else
+            echo "❌ index.html not found!"
+            exit 1
+          fi
 
     - name: Set file permissions
       uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
## Problem
Files were being deployed to `/var/www/drivebit-clients/composeApp/build/dist/wasmJs/productionExecutable/` instead of `/var/www/drivebit-clients/` root directory.

## Solution
- Added step to move files from nested structure to correct location
- Added verification that index.html exists in root directory
- This ensures the web server can find the index.html file

## Testing
- This fix addresses the 403 Forbidden error on drivebit.my
- After merge, deployment should work correctly