### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Drivebit Clients is a Kotlin Multiplatform / Compose Multiplatform front-end (no backend in this repo)
+delivering one product as three clients from `:composeApp`:
+
+- **Web** (`js(IR)`, Compose-for-Web / DOM) — the only client testable headlessly in this VM.
+- **Android** — buildable here (SDK installed), needs an emulator/device to actually run.
+- **iOS** — requires macOS + Xcode; cannot be built or run in this Linux VM.
+
+Standard commands live in `README.md` and `.cursorrules`; run/lint/test/build commands are not duplicated here.
+Note: `README.md`/`.cursorrules` say the web target is `wasmJs` — that is outdated. The real web target is
+`js(IR)`, so the correct dev command is `./gradlew :composeApp:jsBrowserDevelopmentRun` (serves on
+`http://localhost:8080`), and the production build is `./gradlew :composeApp:jsBrowserDistribution`.
+
+### Environment (already provisioned in the VM snapshot)
+
+- **JDK 17** is used for all Gradle builds (matches CI). It is pinned via `~/.gradle/gradle.properties`
+  (`org.gradle.java.home`), so `./gradlew` uses JDK 17 even though the system default `java` is JDK 21.
+  Do not rely on `JAVA_HOME` from the shell.
+- **Android SDK** is installed at `~/android-sdk`. Gradle finds it via `/workspace/local.properties`
+  (`sdk.dir=...`), which is git-ignored and persists in the snapshot. The `:composeApp` module applies the
+  Android application plugin, so the SDK must be resolvable to configure/build *any* target (including web).
+- These are one-off setup steps; a fresh shell needs no `export`s to run Gradle.
+
+### Non-obvious caveats
+
+- **Web app crashes on canvas re-render in headless Chrome.** The web app renders via Skiko/WebGL
+  (`skiko.wasm`, ~8MB). In this VM's software WebGL (SwiftShader), a Compose canvas re-render after an
+  interaction (e.g. selecting a filter) can crash the renderer ("Aw, Snap!" / Compose crash screen). The
+  initial load and a first interaction render correctly. This is an environment GPU limitation, not an app
+  bug — expect this when demoing the web UI headlessly and capture evidence from the first render/interaction.
+- **Images load from GitHub Pages** (`https://antonbutov.github.io/drivebit-clients/images`) at runtime;
+  without internet, the logo/hero images show as broken placeholders but the UI still works.
+- `ktlint` runs with `ignoreFailures = true`, so `ktlintCheck` reports style warnings but still passes.
+- Do not run `./gradlew clean` without explicit permission (per `.cursorrules`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Drivebit Clients Kotlin Multiplatform project in Cursor Cloud and documents durable, non-obvious setup notes for future agents.

This PR only adds `AGENTS.md`. All actual toolchain provisioning (JDK 17, Android SDK, Gradle JDK pinning, `local.properties`) lives in the VM snapshot / update script, not in committed code.

## Environment provisioned

- **JDK 17** installed (matches CI) and pinned for Gradle via `~/.gradle/gradle.properties` so `./gradlew` uses it regardless of the shell's default `java` (JDK 21).
- **Android SDK** (platforms 35 & 36, build-tools 35, platform-tools) installed at `~/android-sdk`; resolved by Gradle via git-ignored `/workspace/local.properties`. Required to configure/build any target since `:composeApp` applies the Android application plugin.
- **Update script:** `./gradlew help --no-daemon` (warms the Gradle distribution + configuration; idempotent).

## Verified

| Check | Command | Result |
|---|---|---|
| Lint | `./gradlew ktlintCheck` | pass |
| Tests | `./gradlew test` | pass |
| Build (web) | `./gradlew :composeApp:jsBrowserDistribution` | pass |
| Android compile | `./gradlew :composeApp:compileDebugKotlinAndroid` | pass |
| Run (web) | `./gradlew :composeApp:jsBrowserDevelopmentRun` → `http://localhost:8080` (HTTP 200) | pass |

## Hello-world task

Loaded the web app and exercised the core car-filter functionality: selecting the "Airports" filter updates the selected button state and swaps the hero car image.

[Web app: All filter selected](https://cursor.com/agents/bc-7dcdd2fe-edd8-4a8e-a8b5-e40efe1ddafe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdrivebit_web_all_selected.webp)
[Web app: Airports filter selected, hero image changed](https://cursor.com/agents/bc-7dcdd2fe-edd8-4a8e-a8b5-e40efe1ddafe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdrivebit_web_airports_selected.webp)

Note: the web app renders via Skiko/WebGL; in this VM's software WebGL the Compose canvas can crash on re-render after an interaction (documented in `AGENTS.md`). The initial render + first interaction work correctly.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dcdd2fe-edd8-4a8e-a8b5-e40efe1ddafe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dcdd2fe-edd8-4a8e-a8b5-e40efe1ddafe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

